### PR TITLE
Fix header issues

### DIFF
--- a/prassee-theme.el
+++ b/prassee-theme.el
@@ -1,4 +1,4 @@
-;;; prassee-theme.el --- A high contrast color theme for Emacs.
+;;; prassee-theme.el --- A high contrast color theme
 
 ;; Copyright (c) 2017 Prassee
 
@@ -23,8 +23,8 @@
 
 ;;; Commentary:
 
-;; A variant of the Doom theme Zenburn for Emacs 25, built on top
-;; of the new built-in theme support in Emacs 25.
+;; A variant of the Doom theme Zenburn for Emacs 24, built on top
+;; of the new built-in theme support in Emacs 24.
 
 ;;; Code:
 


### PR DESCRIPTION
- Every Emacs theme is "for Emacs", so remove redundant wording
- Built-in theme support was added in Emacs 24, not 25

In connection with https://github.com/melpa/melpa/pull/4572.