### PR TITLE
Fix autoload comment

### DIFF
--- a/prassee-theme.el
+++ b/prassee-theme.el
@@ -370,7 +370,7 @@
 ;; set cursor style
 (setq-default cursor-type '(bar . 5))
 
-;; autoload
+;;;###autoload
 (when load-file-name
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))


### PR DESCRIPTION
- Fix `;; autoload` to `;;;###autoload`
- When doesn't written autoload magic comment (`;;;###autoload`), emacs theme framework can't autoload the package directory.